### PR TITLE
Optimisations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 npm-debug.log
 node_modules
+.tags

--- a/lib/GitBlameHelper.js
+++ b/lib/GitBlameHelper.js
@@ -41,6 +41,7 @@ function shortLine(blameInfo, format = "%author%, %relativeTime% ago - %summary%
 
   blameInfo.relativeTime = distanceInWordsToNow(new Date(blameInfo.authorTime * 1000));
   blameInfo.author = blameInfo.author === "Unknown" ? blameInfo.authorEmail : blameInfo.author;
+  blameInfo.summary = blameInfo.summary.replace(/\"/g, `\\\"`);
 
   Object.keys(blameInfo).forEach(token => {
     const tokenRe = new RegExp(`%${token}%`, "g");

--- a/lib/InlineBlameView.js
+++ b/lib/InlineBlameView.js
@@ -4,9 +4,11 @@ import { distanceInWordsToNow } from 'date-fns';
 import { CompositeDisposable, Point } from 'atom';
 import GitBlameHelper from './GitBlameHelper';
 
+const INLINE_BLAME_MESSAGE_VARIABLE = "--inline-blame-message";
+
 export default class InlineBlameView {
-  constructor(editor) {
-    this.editor = editor;
+  constructor() {
+    this.editor = atom.workspace.getActiveTextEditor();
     this.subscriptions = new CompositeDisposable();
     this.decoration = null;
     this.marker = null;
@@ -15,13 +17,11 @@ export default class InlineBlameView {
 
     const throttledUpdate = () => this.throttle(this.updateLine.bind(this));
 
-    this.subscriptions.add(editor.onDidChangeCursorPosition(throttledUpdate));
-    this.subscriptions.add(editor.onDidStopChanging(throttledUpdate));
-    this.subscriptions.add(editor.onDidChange(throttledUpdate));
-    this.subscriptions.add(editor.onDidChangePath(throttledUpdate));
+    window.requestIdleCallback(throttledUpdate); // lazily run once
+    this.subscriptions.add(this.editor.onDidChangeCursorPosition(throttledUpdate));
 
-    this.subscriptions.add(editor.onDidDestroy(() => {
-       this.subscriptions.dispose();
+    this.subscriptions.add(this.editor.onDidDestroy(() => {
+      this.subscriptions.dispose();
     }));
   }
 
@@ -47,12 +47,13 @@ export default class InlineBlameView {
   }
 
   updateLine() {
-    if (!this.editor.buffer.file){
-      return;
-    }
+    if (!this.editor.buffer.file) return;
 
-    const filePath   = this.editor.buffer.file.path;
+    const filePath = this.editor.buffer.file.path;
     this.lineNumber = this.editor.getCursorBufferPosition().row;
+
+    // Don't run on empty lines
+    if (this.editor.lineTextForBufferRow(this.lineNumber).trim() === "") return;
 
     GitBlameHelper
       .run(filePath, this.lineNumber + 1)
@@ -64,24 +65,19 @@ export default class InlineBlameView {
         if (blameInfo.author === "Not Committed Yet") return;
 
         const message   = GitBlameHelper.shortLine(blameInfo, atom.config.get("atom-inline-blame.format"));
+        document.body.style.setProperty(INLINE_BLAME_MESSAGE_VARIABLE, `"${message}`); // set value first
+
         this.marker     = this.editor.markBufferPosition(new Point(this.lineNumber, 0));
         this.decoration = this.editor.decorateMarker(this.marker, {
-          type: 'line',
-          class: 'atom-inline-git-blame'
+          type: "line",
+          class: "atom-inline-git-blame"
         });
-        this.styleEl = document.createElement('style');
-        this.styleEl.type = 'text/css'
-        this.styleEl.innerHTML = `
-          .atom-inline-git-blame[data-screen-row='${this.lineNumber}']::after {
-            content: "${message}";
-          }`;
-        document.getElementsByTagName('head')[0].appendChild(this.styleEl);
       });
   }
 
   removeDecoration() {
+    document.body.style.removeProperty(INLINE_BLAME_MESSAGE_VARIABLE);
     if (this.marker) this.marker.destroy();
     if (this.decoration) this.decoration.destroy();
-    if (this.styleEl) this.styleEl.remove();
   }
 }

--- a/lib/atom-inline-blame.js
+++ b/lib/atom-inline-blame.js
@@ -1,9 +1,11 @@
 'use babel';
 
-import InlineBlameView from './InlineBlameView';
+import { CompositeDisposable } from "atom";
+
+let InlineBlameView;
 
 export default {
-  watchedEditors: null,
+  watchedEditors: new Set([]),
 
   config: {
     format: {
@@ -18,24 +20,37 @@ export default {
     }
   },
 
+  attachBlamer(editor) {
+    if (!editor) return;
+
+    const { id } = editor;
+    if (!this.watchedEditors.has(id)) {
+      if (!InlineBlameView) {
+        InlineBlameView = require("./InlineBlameView"); // lazy load only when needed the first time
+      }
+
+      this.watchedEditors.add(id);
+      new InlineBlameView();
+
+      editor.onDidDestroy(() => this.watchedEditors.delete(id));
+    }
+  },
+
   activate(state) {
-    this.watchedEditors = [];
+    this.subscriptions = new CompositeDisposable();
 
-    this.subscription = atom.workspace.observeTextEditors(editor => {
-      const { id } = editor;
-       if (this.watchedEditors.includes(id)) return;
+    this.subscriptions.add(atom.workspace.onDidChangeActiveTextEditor(this.attachBlamer.bind(this))); // subscribe to changing editors
 
-       this.watchedEditors.push(id);
-       new InlineBlameView(editor);
-
-       editor.onDidDestroy(() => {
-         const thisEditor = this.watchedEditors.indexOf(id);
-         this.watchedEditors.splice(thisEditor, 1);
-       });
-     });
-   },
+    // Annotate current open buffer lazily
+    window.requestIdleCallback(() => {
+      const currentEditor = atom.workspace.getActiveTextEditor();
+      if (currentEditor) {
+        this.attachBlamer.bind(this)(currentEditor);
+      }
+    });
+  },
 
   deactivate() {
-    this.subscription.dispose();
+    this.subscriptions.dispose();
   },
 };

--- a/styles/atom-inline-blame.less
+++ b/styles/atom-inline-blame.less
@@ -6,6 +6,7 @@
 }
 
 .atom-inline-git-blame[data-screen-row]::after {
+  content: var(--inline-blame-message, "");
   opacity: 0.2;
   position: relative;
   left: 25px;


### PR DESCRIPTION
More information in the commit messages, but in brief:

* Remove most of the listeners, now only trigger on cursor change
* Attach to current open TextEditor on idle, which initialises the first message also on idle
* Escape `"`
* Use CSS variable instead of removing and adding a whole `<style>` element every time (is ~300ms faster over 3 tests)

Fixes #2 