### PR TITLE
Camel case format

### DIFF
--- a/menus/atom-inline-blame.json
+++ b/menus/atom-inline-blame.json
@@ -4,10 +4,10 @@
       "label": "Packages",
       "submenu": [
         {
-          "label": "atom-inline-blame",
+          "label": "Atom Inline Blame",
           "submenu": [
             {
-              "label": "Toggle inline blame",
+              "label": "Toggle Inline Blame",
               "command": "atom-inline-blame:toggle"
             }
           ]


### PR DESCRIPTION
All official and non-official packages use _CamelCase_ formatting under the "Packages" menu, without separating dashes. 
Is it possible to update the menu with these changes? Thanks 😊

p.s. here is the visual example after the file update.

<img width="234" alt="Schermata 2021-02-01 alle 12 42 14" src="https://user-images.githubusercontent.com/15775323/106454392-f4c8d900-648a-11eb-9413-755c0f07fe49.png">
